### PR TITLE
Redundant write on EigenDA failure

### DIFF
--- a/store/secondary.go
+++ b/store/secondary.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"net/http"
@@ -8,8 +9,10 @@ import (
 
 	"github.com/Layr-Labs/eigenda-proxy/common"
 	"github.com/Layr-Labs/eigenda-proxy/metrics"
+	verifypackage "github.com/Layr-Labs/eigenda-proxy/verify"
 	"github.com/ethereum-optimism/optimism/op-service/retry"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/rlp"
 
 	"github.com/ethereum/go-ethereum/log"
 )
@@ -151,6 +154,14 @@ func (sm *SecondaryManager) MultiSourceRead(ctx context.Context, commitment []by
 	}
 
 	key := crypto.Keccak256(commitment)
+
+	// check if key is an RLP encoded certificate, if not, assume it's an s3 key
+	var cert verifypackage.Certificate
+	err := rlp.DecodeBytes(commitment, &cert)
+	if err != nil {
+		key = commitment
+	}
+
 	for _, src := range sources {
 		cb := sm.m.RecordSecondaryRequest(src.BackendType().String(), http.MethodGet)
 		data, err := src.Get(ctx, key)
@@ -168,7 +179,14 @@ func (sm *SecondaryManager) MultiSourceRead(ctx context.Context, commitment []by
 
 		// verify cert:data using provided verification function
 		sm.verifyLock.Lock()
-		err = verify(ctx, commitment, data)
+
+		if bytes.Equal(key, commitment) {
+			err = src.Verify(ctx, commitment, data)
+		} else {
+			// verify cert:data using EigenDA verification checks
+			err = verify(ctx, commitment, data)
+		}
+
 		if err != nil {
 			cb(Failed)
 			log.Warn("Failed to verify blob", "err", err, "backend", src.BackendType())


### PR DESCRIPTION
If EigenDA fails for any reason, we still want to write our commitment to the DA layer if we have caches or fallbacks enabled.

Since certificate is not available at this point, a keccak of the payload has to be used as commitment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling and logging for data writing operations.
	- Improved verification process for reading data from secondary storage.

- **Bug Fixes**
	- Addressed potential data loss during write failures by implementing redundant write handling.

- **Documentation**
	- Updated method signatures to reflect changes in error handling and verification logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->